### PR TITLE
Contribution for more precision. FOV Speed Modifer and slower speed with Ctrl.

### DIFF
--- a/Cameras/Hitman2016/InjectableGenericCameraSystem/Core.cpp
+++ b/Cameras/Hitman2016/InjectableGenericCameraSystem/Core.cpp
@@ -114,6 +114,7 @@ void HandleUserInput()
 	mouse.update();
 	bool altPressed = keyboard.keyDown(Keyboard::KEY_LALT) || keyboard.keyDown(Keyboard::KEY_RALT);
 	bool shiftPressed = keyboard.keyDown(Keyboard::KEY_LSHIFT) || keyboard.keyDown(Keyboard::KEY_RSHIFT);
+	bool ctrlPressed = keyboard.keyDown(Keyboard::KEY_LCONTROL) || keyboard.keyDown(Keyboard::KEY_RCONTROL);
 
 	if (keyboard.keyDown(IGCS_KEY_HELP) && altPressed)
 	{
@@ -193,17 +194,18 @@ In v1.8, the alternative camera hasn't been found.
 	}
 	*/
 	//////////////////////////////////////////////////// FOV
+	float FOVmultiplier = altPressed ? FASTER_FOVMULTIPLIER : shiftPressed ? SLOWER_FOVMULTIPLIER : ctrlPressed ? SLOWER_FOVMULTIPLIER2 : 0.005f;
 	if (keyboard.keyDown(IGCS_KEY_FOV_RESET))
 	{
 		ResetFoV();
 	}
 	if (keyboard.keyDown(IGCS_KEY_FOV_DECREASE))
 	{
-		ChangeFoV(-DEFAULT_FOV_SPEED);
+		ChangeFoV(-FOVmultiplier);
 	}
 	if (keyboard.keyDown(IGCS_KEY_FOV_INCREASE))
 	{
-		ChangeFoV(DEFAULT_FOV_SPEED);
+		ChangeFoV(FOVmultiplier);
 	}
 
 	//////////////////////////////////////////////////// CAMERA
@@ -213,7 +215,7 @@ In v1.8, the alternative camera hasn't been found.
 		return;
 	}
 	_camera->ResetMovement();
-	float multiplier = altPressed ? FASTER_MULTIPLIER : shiftPressed ? SLOWER_MULTIPLIER : 1.0f;
+	float multiplier = altPressed ? FASTER_MULTIPLIER : shiftPressed ? SLOWER_MULTIPLIER : ctrlPressed ? SLOWER_MULTIPLIER2 : 1.0f;
 
 	if (keyboard.keyDown(IGCS_KEY_CAMERA_LOCK))
 	{
@@ -315,11 +317,11 @@ In v1.8, the alternative camera hasn't been found.
 		}
 		if (_gamePad->isButtonPressed(IGCS_BUTTON_FOV_DECREASE))
 		{
-			ChangeFoV(-DEFAULT_FOV_SPEED);
+			ChangeFoV(-FOVmultiplier);
 		}
 		if (_gamePad->isButtonPressed(IGCS_BUTTON_FOV_INCREASE))
 		{
-			ChangeFoV(DEFAULT_FOV_SPEED);
+			ChangeFoV(FOVmultiplier);
 		}
 	}
 }
@@ -361,8 +363,9 @@ void DisplayHelp()
 	_consoleWrapper->WriteLine("---[IGCS Help]---------------------------------------------------------------", CONSOLE_WHITE);
 	_consoleWrapper->WriteLine("INS                                      : Enable/Disable camera");
 	_consoleWrapper->WriteLine("HOME                                     : Lock/unlock camera movement");
-	_consoleWrapper->WriteLine("ALT+rotate/move                          : Faster rotate / move");
-	_consoleWrapper->WriteLine("SHIFT+rotate/move                        : Slower rotate / move");
+	_consoleWrapper->WriteLine("ALT+rotate/move/FoV                      : Faster rotate / move / FoV");
+	_consoleWrapper->WriteLine("SHIFT+rotate/move/FoV                    : Slower rotate / move / FoV");
+	_consoleWrapper->WriteLine("CTRL+rotate/move/FoV                     : Even Slower rotate / move /FoV");
 	_consoleWrapper->WriteLine("Controller A-button + left/right-stick   : Faster rotate / move");
 	_consoleWrapper->WriteLine("Controller X-button + left/right-stick   : Slower rotate / move");
 	_consoleWrapper->WriteLine("Arrow up/down or mouse or right-stick    : Rotate camera up/down");

--- a/Cameras/Hitman2016/InjectableGenericCameraSystem/Defaults.h
+++ b/Cameras/Hitman2016/InjectableGenericCameraSystem/Defaults.h
@@ -34,13 +34,16 @@
 // System defaults
 #define FRAME_SLEEP				8		// in milliseconds
 #define FASTER_MULTIPLIER		3.0f
-#define SLOWER_MULTIPLIER		0.15f
+#define SLOWER_MULTIPLIER		0.05f
+#define SLOWER_MULTIPLIER2		0.01f
+#define FASTER_FOVMULTIPLIER    0.01f
+#define SLOWER_FOVMULTIPLIER	0.001f
+#define SLOWER_FOVMULTIPLIER2	0.00025f
 #define MOUSE_SPEED_CORRECTION	0.1f	// to correct for the mouse-deltas related to normal rotation.
 #define DEFAULT_MOVEMENT_SPEED	0.05f
 #define DEFAULT_ROTATION_SPEED	0.01f
 #define DEFAULT_FOV_RADIANS		0.7f
 #define DEFAULT_FOV_DEGREES		40.0f
-#define DEFAULT_FOV_SPEED		0.005f
 
 // Keyboard camera control
 #define IGCS_KEY_CAMERA_ENABLE	Keyboard::KEY_INSERT


### PR DESCRIPTION
I only made the change to the Hitman keyboard camera. Feel free to transfer it to Tomb raider and the controller cameras as well.
Feel free to clean up/adapt/rename/change/dispose of the code as you see fit.
I don't use Ctrl for Instinct so I don't have an issue with timestop stopping. So, that will need to be remapped.

BTW Thanks for making this tool! 
If you're so inclined, check out some screens I've made using it:
http://www.hitmanforum.com/t/the-hitman-screenshot-thread/145/910
Others on the thread are putting it to good use as well.