### PR TITLE
Hellblade camera v1.0.1 updates

### DIFF
--- a/Cameras/Hellblade/InjectableGenericCameraSystem/GameConstants.h
+++ b/Cameras/Hellblade/InjectableGenericCameraSystem/GameConstants.h
@@ -33,7 +33,7 @@ namespace IGCS::GameSpecific
 	#define GAME_NAME									"Hellblade: Senua's Sacrifice v1.0"
 	#define CAMERA_VERSION								"1.0.0"
 	#define CAMERA_CREDITS								"Otis_Inf"
-	#define GAME_WINDOW_TITLE							"Hellblade: Senua's Sacrifice "
+	#define GAME_WINDOW_TITLE							"Hellblade"
 	#define INITIAL_PITCH_RADIANS						0.0f	// around X axis	(right)
 	#define INITIAL_YAW_RADIANS							0.0f	// around Y axis	(into the screen)
 	#define INITIAL_ROLL_RADIANS						0.0f	// aruond Z axis	(up)

--- a/Cameras/Hellblade/InjectableGenericCameraSystem/GameConstants.h
+++ b/Cameras/Hellblade/InjectableGenericCameraSystem/GameConstants.h
@@ -31,7 +31,7 @@ namespace IGCS::GameSpecific
 {
 	// Mandatory constants to define for a game
 	#define GAME_NAME									"Hellblade: Senua's Sacrifice v1.0"
-	#define CAMERA_VERSION								"1.0.0"
+	#define CAMERA_VERSION								"1.0.1"
 	#define CAMERA_CREDITS								"Otis_Inf"
 	#define GAME_WINDOW_TITLE							"Hellblade"
 	#define INITIAL_PITCH_RADIANS						0.0f	// around X axis	(right)
@@ -51,6 +51,7 @@ namespace IGCS::GameSpecific
 	// AOB Keys for interceptor's AOB scanner
 	#define CAMERA_ADDRESS_INTERCEPT_KEY				"AOB_CAMERA_ADDRESS_INTERCEPT"
 	#define FOV_INTERCEPT_KEY							"AOB_FOV_INTERCEPT"
+	#define CAMERA_WRITE_INTERCEPT_KEY					"AOB_CAMERA_WRITE_INTERCEPT"
 
 	// Indices in the structures read by interceptors 
 	#define COORDS_IN_STRUCT_OFFSET						0x480

--- a/Cameras/Hellblade/InjectableGenericCameraSystem/InterceptorHelper.cpp
+++ b/Cameras/Hellblade/InjectableGenericCameraSystem/InterceptorHelper.cpp
@@ -39,12 +39,14 @@ using namespace std;
 extern "C" {
 	void cameraStructInterceptor();
 	void fovReadInterceptor();
+	void cameraWriteInterceptor();
 }
 
 // external addresses used in asm.
 extern "C" {
 	LPBYTE _cameraStructInterceptionContinue = nullptr;
 	LPBYTE _fovReadInterceptionContinue = nullptr;
+	LPBYTE _cameraWriteInterceptionContinue = nullptr;
 }
 
 
@@ -52,9 +54,10 @@ namespace IGCS::GameSpecific::InterceptorHelper
 {
 	void initializeAOBBlocks(LPBYTE hostImageAddress, DWORD hostImageSize, map<string, AOBBlock*> &aobBlocks)
 	{
-		aobBlocks[CAMERA_ADDRESS_INTERCEPT_KEY] = new AOBBlock(CAMERA_ADDRESS_INTERCEPT_KEY, "F2 0F 11 87 ?? ?? ?? ?? F2 0F 10 44 24 ?? F2 0F 11 87 ?? ?? ?? ?? 0F10 44 24 ?? 89 87 ?? ?? ?? ?? 8B 44 24 ?? 89 87 ?? ?? ?? ?? 8B 44 24 ?? ", 1);	
+		aobBlocks[CAMERA_ADDRESS_INTERCEPT_KEY] = new AOBBlock(CAMERA_ADDRESS_INTERCEPT_KEY, "F2 0F 11 87 ?? ?? ?? ?? F2 0F 10 44 24 ?? F2 0F 11 87 ?? ?? ?? ?? 0F10 44 24 ?? 89 87 ?? ?? ?? ?? 8B 44 24 ?? 89 87 ?? ?? ?? ?? 8B 44 24 ??", 1);	
 		aobBlocks[FOV_INTERCEPT_KEY] = new AOBBlock(FOV_INTERCEPT_KEY, "F3 0F10 81 14 04 00 00 0F 57 C9 0F 2F C1 77 08 F3 0F 10 81", 1);
-		
+		aobBlocks[CAMERA_WRITE_INTERCEPT_KEY] = new AOBBlock(CAMERA_WRITE_INTERCEPT_KEY, "F2 0F 11 83 ?? ?? ?? ?? F2 0F 10 44 24 ?? F2 0F 11 83 ?? ?? ?? ?? 0F 10 44 24", 1);
+
 		map<string, AOBBlock*>::iterator it;
 		bool result = true;
 		for (it = aobBlocks.begin(); it != aobBlocks.end(); it++)
@@ -81,5 +84,6 @@ namespace IGCS::GameSpecific::InterceptorHelper
 	void setPostCameraStructHooks(map<string, AOBBlock*> &aobBlocks, LPBYTE hostImageAddress)
 	{
 		GameImageHooker::setHook(aobBlocks[FOV_INTERCEPT_KEY], 0x18, &_fovReadInterceptionContinue, &fovReadInterceptor);
+		GameImageHooker::setHook(aobBlocks[CAMERA_WRITE_INTERCEPT_KEY], 0x2B, &_cameraWriteInterceptionContinue, &cameraWriteInterceptor);
 	}
 }

--- a/Cameras/Hellblade/InjectableGenericCameraSystem/System.cpp
+++ b/Cameras/Hellblade/InjectableGenericCameraSystem/System.cpp
@@ -140,6 +140,7 @@ namespace IGCS
 				// it's going to be enabled, so cache the original values before we enable it so we can restore it afterwards
 				CameraManipulator::cacheOriginalCameraValues();
 				_camera.resetAngles();
+				CameraManipulator::resetFoV();
 			}
 			g_cameraEnabled = g_cameraEnabled == 0 ? (byte)1 : (byte)0;
 			displayCameraState();

--- a/Cameras/Hellblade/InjectableGenericCameraSystem/Utils.cpp
+++ b/Cameras/Hellblade/InjectableGenericCameraSystem/Utils.cpp
@@ -45,7 +45,8 @@ namespace IGCS::Utils
 			int bufsize = GetWindowTextLength(handle) + 1;
 			LPWSTR title = new WCHAR[bufsize];
 			GetWindowText(handle, title, bufsize);
-			toReturn &= (_wcsicmp(title, TEXT(GAME_WINDOW_TITLE)) == 0);
+			// trick to do a 'startswith' compare. Will only return 0 if the string actually starts with the fragment we want to compare with
+			toReturn &= (wcsncmp(title, TEXT(GAME_WINDOW_TITLE), strlen(GAME_WINDOW_TITLE))==0);
 			// convert title to char* so we can display it
 			_bstr_t titleAsBstr(title);
 			const char* titleAsChar = titleAsBstr;		// char conversion copy

--- a/Cameras/Hellblade/ReadMe.md
+++ b/Cameras/Hellblade/ReadMe.md
@@ -2,8 +2,8 @@ Injectable camera for Hellblade: Senua's Sacrifice
 ============================
 
 Current supported game version: v1.0.0+  
-Camera version: 1.0.0  
-Camera release binaries: https://github.com/FransBouma/InjectableGenericCameraSystem/releases/tag/Hellblade_100   
+Camera version: 1.0.1  
+Camera release binaries: https://github.com/FransBouma/InjectableGenericCameraSystem/releases/tag/Hellblade_101   
 Credits: Otis_Inf
 
 ### How to use


### PR DESCRIPTION
Support for menu / pause camera write interception, so the camera will work when timestop is active. Also during ansel this now works.

FOV is reset when the camera is enabled, it was previously left at the value of the previous session.

Changed window find code to work with the start fragment of the string which is more robust


