### PR TITLE
Feature or bugfix branch

### DIFF
--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/CameraManipulator.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/CameraManipulator.cpp
@@ -61,14 +61,14 @@ namespace IGCS::GameSpecific::CameraManipulator
 
 	// newValue: 1 == time should be frozen, 0 == normal gameplay
 	// returns true if the game was stopped by this call, false if the game was either already stopped or the state didn't change.
-	bool setTimeStopValue(byte newValue)
+	bool setTimeStopValue(BYTE newValue)
 	{
 		if (nullptr == g_timestopStructAddress)
 		{
 			return false;
 		}
 		LPBYTE timestopInMemory = (g_timestopStructAddress + TIMESTOP_IN_STRUCT_OFFSET);
-		bool toReturn = *timestopInMemory == (byte)0 && (newValue == (byte)1);
+		bool toReturn = *timestopInMemory == (BYTE)0 && (newValue == (BYTE)1);
 		*timestopInMemory = newValue;
 		return toReturn;
 	}

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/CameraManipulator.h
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/CameraManipulator.h
@@ -28,16 +28,14 @@
 #pragma once
 #include "stdafx.h"
 
-using namespace DirectX;
-
 namespace IGCS::GameSpecific::CameraManipulator
 {
-	void writeNewCameraValuesToGameData(XMFLOAT3 newCoords, XMVECTOR newLookQuaternion);
+	void writeNewCameraValuesToGameData(DirectX::XMFLOAT3 newCoords, DirectX::XMVECTOR newLookQuaternion);
 	void restoreOriginalValuesAfterCameraDisable();
 	void cacheOriginalValuesBeforeCameraEnable();
 	void setResolutionScaleMenuValueAddress(LPBYTE address);
-	bool setTimeStopValue(byte newValue);
-	XMFLOAT3 getCurrentCameraCoords();
+	bool setTimeStopValue(BYTE newValue);
+	DirectX::XMFLOAT3 getCurrentCameraCoords();
 	void resetFoV();
 	void changeFoV(float amount);
 	bool isCameraFound();

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Defaults.h
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Defaults.h
@@ -69,7 +69,7 @@ namespace IGCS
 	#define IGCS_BUTTON_FASTER			Gamepad::button_t::Y
 	#define IGCS_BUTTON_SLOWER			Gamepad::button_t::X
 
-	static const byte jmpFarInstructionBytes[6] = { 0xff, 0x25, 0, 0, 0, 0 };	// instruction bytes for jmp qword ptr [0000]
+	static const BYTE jmpFarInstructionBytes[6] = { 0xff, 0x25, 0, 0, 0, 0 };	// instruction bytes for jmp qword ptr [0000]
 
 	#define DEVICE_ID_KEYBOARD_MOUSE			0
 	#define DEVICE_ID_GAMEPAD					1

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/GameImageHooker.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/GameImageHooker.cpp
@@ -43,7 +43,7 @@ namespace IGCS::GameImageHooker
 		*interceptionContinue = startOfHookAddress + continueOffset;
 #ifdef _WIN64
 		// x64
-		byte instruction[14];	// 6 bytes of the jmp qword ptr [0] and 8 bytes for the real address which is stored right after the 6 bytes of jmp qword ptr [0] bytes 
+		BYTE instruction[14];	// 6 bytes of the jmp qword ptr [0] and 8 bytes for the real address which is stored right after the 6 bytes of jmp qword ptr [0] bytes 
 								// write bytes of jmp qword ptr [address], which is jmp qword ptr 0 offset.
 		memcpy(instruction, jmpFarInstructionBytes, sizeof(jmpFarInstructionBytes));
 		// now write the address. Do this with a recast of the pointer to an __int64 pointer to avoid endianmess.
@@ -53,7 +53,7 @@ namespace IGCS::GameImageHooker
 		// x86
 		// we will write a jmp <relative address> as x86 doesn't have a jmp <absolute address>. 
 		// calculate this relative address by using Destination - Current, which is: &asmFunction - (<base> + startOffset + 5), as jmp <relative> is 5 bytes.
-		byte instruction[5];
+		BYTE instruction[5];
 		instruction[0] = 0xE9;	// JMP relative
 		DWORD targetAddress = (DWORD)asmFunction - (((DWORD)startOfHookAddress) + 5);
 		DWORD* targetAddressLocationInInstruction = (DWORD*)&instruction[1];
@@ -80,7 +80,7 @@ namespace IGCS::GameImageHooker
 
 
 	// Writes the bytes pointed at by bufferToWrite starting at address startAddress, for the length in 'length'.
-	void writeRange(LPBYTE startAddress, byte* bufferToWrite, int length)
+	void writeRange(LPBYTE startAddress, BYTE* bufferToWrite, int length)
 	{
 		SIZE_T noBytesWritten;
 		WriteProcessMemory(OpenProcess(PROCESS_VM_OPERATION | PROCESS_VM_WRITE, FALSE, GetCurrentProcessId()), startAddress, bufferToWrite, length, &noBytesWritten);
@@ -88,7 +88,7 @@ namespace IGCS::GameImageHooker
 
 
 	// Writes the bytes pointed at by bufferToWrite starting at address startAddress, for the length in 'length'.
-	void writeRange(AOBBlock* hookData, byte* bufferToWrite, int length)
+	void writeRange(AOBBlock* hookData, BYTE* bufferToWrite, int length)
 	{
 		writeRange(hookData->locationInImage() + hookData->customOffset(), bufferToWrite, length);
 	}
@@ -97,13 +97,13 @@ namespace IGCS::GameImageHooker
 	// Writes NOP opcodes to a range of memory.
 	void nopRange(LPBYTE startAddress, int length)
 	{
-		byte* nopBuffer;
+		BYTE* nopBuffer;
 		if (length < 0 || length>1024)
 		{
 			// no can/wont do 
 			return;
 		}
-		nopBuffer = (byte*)malloc(length * sizeof(byte));
+		nopBuffer = (BYTE*)malloc(length * sizeof(BYTE));
 		for (int i = 0; i < length; i++)
 		{
 			nopBuffer[i] = 0x90;

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/GameImageHooker.h
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/GameImageHooker.h
@@ -34,6 +34,6 @@ namespace IGCS::GameImageHooker
 	void nopRange(AOBBlock* hookData, int length);
 	void setHook(LPBYTE hostImageAddress, DWORD startOffset, DWORD continueOffset, LPBYTE* interceptionContinue, void* asmFunction);
 	void setHook(AOBBlock* hookData, DWORD continueOffset, LPBYTE* interceptionContinue, void* asmFunction);
-	void writeRange(LPBYTE startAddress, byte* bufferToWrite, int length);
-	void writeRange(AOBBlock* hookData, byte* bufferToWrite, int length);
+	void writeRange(LPBYTE startAddress, BYTE* bufferToWrite, int length);
+	void writeRange(AOBBlock* hookData, BYTE* bufferToWrite, int length);
 }

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Globals.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Globals.cpp
@@ -33,7 +33,7 @@
 // data shared with asm functions. This is allocated here, 'C' style and not in some datastructure as passing that to 
 // MASM is rather tedious. 
 extern "C" {
-	byte g_cameraEnabled = 0;
+	BYTE g_cameraEnabled = 0;
 }
 
 

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Globals.h
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Globals.h
@@ -33,8 +33,8 @@
 #include "CDataFile.h"
 #include "Utils.h"
 
-extern "C" byte g_cameraEnabled;
-extern "C" byte g_gamePaused;
+extern "C" BYTE g_cameraEnabled;
+extern "C" BYTE g_gamePaused;
 
 namespace IGCS
 {

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InjectableGenericCameraSystem.vcxproj
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InjectableGenericCameraSystem.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{A27B0E55-A5C9-4DCD-9C74-2C8074757FBE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestInjectDll</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <ProjectName>ACOriginsCameraTools</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -140,22 +140,16 @@
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;TESTINJECTDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>IMGUI_DISABLE_OBSOLETE_FUNCTIONS;NDEBUG;_WINDOWS;_USRDLL;TESTINJECTDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\dependencies\MinHook\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <Optimization>Disabled</Optimization>
-      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>dinput8.lib;dxguid.lib.;Xinput9_1_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>C:\Users\frans.SD\Documents\GitHub\InjectableGenericCameraSystem\AdditionalLibs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <OptimizeReferences>true</OptimizeReferences>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InjectableGenericCameraSystem.vcxproj
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InjectableGenericCameraSystem.vcxproj
@@ -145,16 +145,17 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\dependencies\MinHook\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
-      <WholeProgramOptimization>false</WholeProgramOptimization>
       <Optimization>Disabled</Optimization>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>dinput8.lib;dxguid.lib.;Xinput9_1_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>C:\Users\frans.SD\Documents\GitHub\InjectableGenericCameraSystem\AdditionalLibs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Input.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Input.cpp
@@ -33,6 +33,7 @@
 #include "OverlayConsole.h"
 #include "OverlayControl.h"
 #include <mutex>
+#include <atomic>
 
 namespace IGCS::Input
 {
@@ -40,16 +41,11 @@ namespace IGCS::Input
 
 	// The key/mouse states are unprotected for write/read. This is initially bad, but protecting it with a mutex is difficult as the present call
 	// will read it and multiple calls from that thread causes mutex problems. For now they're unprotected (not that bad, the next frame it will be corrected anyway).
-	static byte g_keyStates[256];		// 0x0==nothing, 0x88==key is down this frame, 0x08==key is released, 0x80==key was down previous frame.
-	static byte g_mouseButtonStates[3];	// 0x0==nothing, 0x88==button is down this frame, 0x08==button is released, 0x80==button was down previous frame.
+	static BYTE g_keyStates[256];		// 0x0==nothing, 0x88==key is down this frame, 0x08==key is released, 0x80==key was down previous frame.
+	static BYTE g_mouseButtonStates[3];	// 0x0==nothing, 0x88==button is down this frame, 0x08==button is released, 0x80==button was down previous frame.
 	static short g_mouseWheelDelta = 0;
-
-	// I know, multi-threaded programming, but these two values are scalars, and read/write of multiple threads (which is the case) doesn't really 
-	// matter: wrapping this in mutexes is overkill: x86 processors can write up to 7 bytes in an atomic instruction, more than enough for a long, 
-	// and the values are used in a system which is updated rapidly, so if a write overlaps a read, the next frame will correct that. The 'volatile'
-	// keyword should be enough to mark them for the optimizer not to mess with them. 
-	volatile static long _deltaMouseX = 0;
-	volatile static long _deltaMouseY = 0;
+	static atomic_long _deltaMouseX = 0;
+	static atomic_long _deltaMouseY = 0;
 	
 	void setMouseButtonState(int button, bool down);
 

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InputHooker.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InputHooker.cpp
@@ -168,7 +168,6 @@ namespace IGCS::InputHooker
 	// they're enabled. 
 	void setInputHooks()
 	{
-		MH_Initialize();
 		if (MH_CreateHookApiEx(L"xinput9_1_0", "XInputGetState", &detourXInputGetState, &hookedXInputGetState) != MH_OK)
 		{
 			OverlayConsole::instance().logError("Hooking XInput9_1_0 failed!");

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InterceptorHelper.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/InterceptorHelper.cpp
@@ -180,9 +180,9 @@ namespace IGCS::GameSpecific::InterceptorHelper
 		if (enabled)
 		{
 			// enable writes
-			byte originalStatementBytes1[8] = { 0xF3, 0x0F, 0x11, 0xB7, 0x64, 0x02, 0x00, 0x00 };			// ACOrigins.exe+1058756 - F3 0F11 B7 64020000   - movss [rdi+00000264],xmm6
+			BYTE originalStatementBytes1[8] = { 0xF3, 0x0F, 0x11, 0xB7, 0x64, 0x02, 0x00, 0x00 };			// ACOrigins.exe+1058756 - F3 0F11 B7 64020000   - movss [rdi+00000264],xmm6
 			GameImageHooker::writeRange(aobBlocks[FOV_WRITE1_INTERCEPT_KEY], originalStatementBytes1, 8);
-			byte originalStatementBytes2[9] = { 0xF3, 0x44, 0x0F, 0x11, 0x93, 0x64, 0x02, 0x00, 0x00 };		// ACOrigins.exe+109C584 - F3 44 0F11 93 64020000  - movss [rbx+00000264],xmm10
+			BYTE originalStatementBytes2[9] = { 0xF3, 0x44, 0x0F, 0x11, 0x93, 0x64, 0x02, 0x00, 0x00 };		// ACOrigins.exe+109C584 - F3 44 0F11 93 64020000  - movss [rbx+00000264],xmm10
 			GameImageHooker::writeRange(aobBlocks[FOV_WRITE2_INTERCEPT_KEY], originalStatementBytes2, 9);
 		}
 		else

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayConsole.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayConsole.cpp
@@ -10,6 +10,16 @@ namespace IGCS
 	#define CONSOLE_DEBUG_PREFIX "[DEBUG]"
 	#define CONSOLE_ERROR_PREFIX ">> ERROR <<"
 
+
+	void OverlayConsole::clear()
+	{
+		EnterCriticalSection(&_contentCriticalSection);
+		_buf.clear();
+		_lineOffsets.clear();
+		LeaveCriticalSection(&_contentCriticalSection);
+	}
+
+
 	void OverlayConsole::logDebug(const char* fmt, ...) IM_FMTARGS(2)
 	{
 #ifdef _DEBUG
@@ -47,6 +57,7 @@ namespace IGCS
 
 	void OverlayConsole::logLinev(const char* fmt, va_list args)
 	{
+		EnterCriticalSection(&_contentCriticalSection);
 		int old_size = _buf.size();
 		va_list args_copy;
 		va_copy(args_copy, args);
@@ -60,6 +71,7 @@ namespace IGCS
 			}
 		}
 		_scrollToBottom = true;
+		LeaveCriticalSection(&_contentCriticalSection);
 	}
 
 
@@ -79,6 +91,8 @@ namespace IGCS
 		{
 			ImGui::LogToClipboard();
 		}
+
+		EnterCriticalSection(&_contentCriticalSection);
 		const char* buf_begin = _buf.begin();
 		const char* line = buf_begin;
 		for (int line_no = 0; line != NULL; line_no++)
@@ -101,7 +115,7 @@ namespace IGCS
 			}
 			line = line_end && line_end[1] ? line_end + 1 : NULL;
 		}
-
+		LeaveCriticalSection(&_contentCriticalSection);
 		if (_scrollToBottom)
 		{
 			ImGui::SetScrollHere(1.0f);

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayConsole.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayConsole.cpp
@@ -14,8 +14,8 @@ namespace IGCS
 	void OverlayConsole::clear()
 	{
 		EnterCriticalSection(&_contentCriticalSection);
-		_buf.clear();
-		_lineOffsets.clear();
+			_buf.clear();
+			_lineOffsets.clear();
 		LeaveCriticalSection(&_contentCriticalSection);
 	}
 
@@ -58,19 +58,19 @@ namespace IGCS
 	void OverlayConsole::logLinev(const char* fmt, va_list args)
 	{
 		EnterCriticalSection(&_contentCriticalSection);
-		int old_size = _buf.size();
-		va_list args_copy;
-		va_copy(args_copy, args);
-		_buf.appendv(fmt, args_copy);
+			int old_size = _buf.size();
+			va_list args_copy;
+			va_copy(args_copy, args);
+			_buf.appendv(fmt, args_copy);
 
-		for (int new_size = _buf.size(); old_size < new_size; old_size++)
-		{
-			if (_buf[old_size] == '\n')
+			for (int new_size = _buf.size(); old_size < new_size; old_size++)
 			{
-				_lineOffsets.push_back(old_size);
+				if (_buf[old_size] == '\n')
+				{
+					_lineOffsets.push_back(old_size);
+				}
 			}
-		}
-		_scrollToBottom = true;
+			_scrollToBottom = true;
 		LeaveCriticalSection(&_contentCriticalSection);
 	}
 
@@ -93,28 +93,28 @@ namespace IGCS
 		}
 
 		EnterCriticalSection(&_contentCriticalSection);
-		const char* buf_begin = _buf.begin();
-		const char* line = buf_begin;
-		for (int line_no = 0; line != NULL; line_no++)
-		{
-			const char* line_end = (line_no < _lineOffsets.Size) ? buf_begin + _lineOffsets[line_no] : NULL;
-			if (_filter.PassFilter(line, line_end))
+			const char* buf_begin = _buf.begin();
+			const char* line = buf_begin;
+			for (int line_no = 0; line != NULL; line_no++)
 			{
-				ImVec4 col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f); 
-				if (Utils::stringStartsWith(line, CONSOLE_ERROR_PREFIX))
+				const char* line_end = (line_no < _lineOffsets.Size) ? buf_begin + _lineOffsets[line_no] : NULL;
+				if (_filter.PassFilter(line, line_end))
 				{
-					col = ImColor(1.0f, 0.4f, 0.4f, 1.0f);
+					ImVec4 col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f); 
+					if (Utils::stringStartsWith(line, CONSOLE_ERROR_PREFIX))
+					{
+						col = ImColor(1.0f, 0.4f, 0.4f, 1.0f);
+					}
+					else if (Utils::stringStartsWith(line, CONSOLE_DEBUG_PREFIX))
+					{
+						col = ImVec4(1.0f, 1.0f, 1.0f, 0.6f);
+					}
+					ImGui::PushStyleColor(ImGuiCol_Text, col);
+					ImGui::TextUnformatted(line, line_end);
+					ImGui::PopStyleColor();
 				}
-				else if (Utils::stringStartsWith(line, CONSOLE_DEBUG_PREFIX))
-				{
-					col = ImVec4(1.0f, 1.0f, 1.0f, 0.6f);
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, col);
-				ImGui::TextUnformatted(line, line_end);
-				ImGui::PopStyleColor();
+				line = line_end && line_end[1] ? line_end + 1 : NULL;
 			}
-			line = line_end && line_end[1] ? line_end + 1 : NULL;
-		}
 		LeaveCriticalSection(&_contentCriticalSection);
 		if (_scrollToBottom)
 		{

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayConsole.h
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayConsole.h
@@ -15,8 +15,7 @@ namespace IGCS
 			static OverlayConsole instance;
 			return instance;
 		}
-
-		void clear() { _buf.clear(); _lineOffsets.clear(); }
+		void clear();
 		void logDebug(const char* fmt, ...) IM_FMTARGS(2);
 		void logError(const char* fmt, ...) IM_FMTARGS(2);
 		void logLine(const char* fmt, ...)  IM_FMTARGS(2);
@@ -26,9 +25,13 @@ namespace IGCS
 		void operator=(OverlayConsole const&) = delete;
 
 	private:
-		OverlayConsole() {}
+		OverlayConsole() 
+		{
+			InitializeCriticalSectionAndSpinCount(&_contentCriticalSection, 0x400);
+		}
 		void logLinev(const char* fmt, va_list args);
 
+		CRITICAL_SECTION	_contentCriticalSection;
 		ImGuiTextBuffer     _buf;
 		ImGuiTextFilter     _filter;
 		ImVector<int>       _lineOffsets;        // Index to lines offset

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayControl.h
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/OverlayControl.h
@@ -4,6 +4,7 @@
 
 namespace IGCS::OverlayControl
 {
+	void init();
 	void toggleOverlay();
 	void renderOverlay();
 	bool isMainMenuVisible();

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/System.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/System.cpp
@@ -40,6 +40,7 @@
 #include "UniversalD3D11Hook.h"
 #include "OverlayConsole.h"
 #include "OverlayControl.h"
+#include "MinHook.h"
 
 namespace IGCS
 {
@@ -324,10 +325,12 @@ namespace IGCS
 	// Initializes system. Will block till camera struct is found.
 	void System::initialize()
 	{
+		MH_Initialize();
+		OverlayControl::init();
 		Globals::instance().mainWindowHandle(Utils::findMainWindow(GetCurrentProcessId()));
 		InputHooker::setInputHooks();
-		DX11Hooker::initializeHook();
 		Input::registerRawInput();
+		DX11Hooker::initializeHook();
 
 		GameSpecific::InterceptorHelper::initializeAOBBlocks(_hostImageAddress, _hostImageSize, _aobBlocks);
 		GameSpecific::InterceptorHelper::setCameraStructInterceptorHook(_aobBlocks);

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/System.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/System.cpp
@@ -95,9 +95,9 @@ namespace IGCS
 		}
 
 		// calculate new camera values. We have two cameras, but they might not be available both, so we have to test before we do anything. 
-		XMVECTOR newLookQuaternion = _camera.calculateLookQuaternion();
-		XMFLOAT3 currentCoords; 
-		XMFLOAT3 newCoords;
+		DirectX::XMVECTOR newLookQuaternion = _camera.calculateLookQuaternion();
+		DirectX::XMFLOAT3 currentCoords;
+		DirectX::XMFLOAT3 newCoords;
 		if (GameSpecific::CameraManipulator::isCameraFound())
 		{
 			currentCoords = GameSpecific::CameraManipulator::getCurrentCameraCoords();
@@ -147,7 +147,7 @@ namespace IGCS
 				CameraManipulator::cacheOriginalValuesBeforeCameraEnable();
 				_camera.resetAngles();
 			}
-			g_cameraEnabled = g_cameraEnabled == 0 ? (byte)1 : (byte)0;
+			g_cameraEnabled = g_cameraEnabled == 0 ? (BYTE)1 : (BYTE)0;
 			displayCameraState();
 			Sleep(350);				// wait for 350ms to avoid fast keyboard hammering
 		}
@@ -391,7 +391,7 @@ namespace IGCS
 
 	void System::toggleTimestopState()
 	{
-		_timeStopped = _timeStopped == 0 ? (byte)1 : (byte)0;
+		_timeStopped = _timeStopped == 0 ? (BYTE)1 : (BYTE)0;
 		OverlayControl::addNotification(_timeStopped ? "Game paused" : "Game unpaused");
 		CameraManipulator::setTimeStopValue(_timeStopped);
 	}

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/UniversalD3D11Hook.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/UniversalD3D11Hook.cpp
@@ -10,6 +10,7 @@
 #include "OverlayControl.h"
 #include "OverlayConsole.h"
 #include "Input.h"
+#include <atomic>
 
 #pragma comment(lib, "d3d11.lib")
 
@@ -40,10 +41,9 @@ namespace IGCS::DX11Hooker
 	static D3D11ResizeBuffersHook hookedD3D11ResizeBuffers = nullptr;
 
 	static bool _tmpSwapChainInitialized = false;
-	static volatile bool _showWindow = true;
-	static volatile bool _imGuiInitializing = false;
-	static volatile bool _initializeDeviceAndContext = true;
-	static volatile bool _presentInProgress = false;
+	static atomic_bool _imGuiInitializing = false;
+	static atomic_bool _initializeDeviceAndContext = true;
+	static atomic_bool _presentInProgress = false;
 
 	HRESULT __stdcall detourD3D11ResizeBuffers(IDXGISwapChain* pSwapChain, UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags)
 	{
@@ -241,9 +241,6 @@ namespace IGCS::DX11Hooker
 		style.Colors[ImGuiCol_Header] = ImVec4(0.50f, 0.50f, 0.53f, 0.49f);
 		style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.47f, 0.47f, 0.49f, 1.00f);
 		style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.40f, 0.40f, 0.44f, 0.31f);
-		style.Colors[ImGuiCol_Column] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style.Colors[ImGuiCol_ColumnHovered] = ImVec4(0.23f, 0.23f, 0.24f, 1.00f);
-		style.Colors[ImGuiCol_ColumnActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
 		style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.44f, 0.44f, 0.44f, 0.30f);
 		style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.59f, 0.59f, 0.59f, 1.00f);
 		style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.59f, 0.59f, 0.59f, 1.00f);

--- a/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Utils.cpp
+++ b/Cameras/AssassinsCreedOrigins/InjectableGenericCameraSystem/Utils.cpp
@@ -153,7 +153,7 @@ namespace IGCS::Utils
 
 	LPBYTE findAOBPattern(LPBYTE imageAddress, DWORD imageSize, AOBBlock* const toScanFor)
 	{
-		register BYTE firstByte = *(toScanFor->bytePattern());
+		BYTE firstByte = *(toScanFor->bytePattern());
 		__int64 length = (__int64)imageAddress + imageSize - toScanFor->patternSize();
 
 		LPBYTE toReturn = nullptr;
@@ -162,7 +162,7 @@ namespace IGCS::Utils
 		{
 			// reset the pointer found, as we're not interested in this occurrence, we need a following occurrence.
 			toReturn = nullptr;
-			for (register __int64 i = (__int64)startOfScan; i < length; i += 4)
+			for (__int64 i = (__int64)startOfScan; i < length; i += 4)
 			{
 				unsigned x = *(unsigned*)(i);
 
@@ -216,6 +216,7 @@ namespace IGCS::Utils
 	// next instruction starts.
 	LPBYTE calculateAbsoluteAddress(AOBBlock* locationData, int nextOpCodeOffset)
 	{
+		assert(locationData != nullptr);
 		// ripRelativeValueAddress is the absolute address of a DWORD value which is a RIP relative offset. A calculation has to be performed on x64 to
 		// calculate from that rip relative value and its location the real absolute address it refers to. That address is returned.
 		LPBYTE ripRelativeValueAddress = locationData->locationInImage() + locationData->customOffset();

--- a/dependencies/MinHook.vcxproj
+++ b/dependencies/MinHook.vcxproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{783FEDFB-5124-4F8C-87BC-70AA8490266B}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -28,7 +28,7 @@
     <IntDir>$(SolutionDir)intermediate\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">


### PR DESCRIPTION
ACO: Migrated to vs2017. Fixed release build issue: used atomic instead of volatile

This solved the weird memory stuff, as boolean/float values aren't optimized away anymore as constants, as they're now using the std::atomic struct instead.